### PR TITLE
added a flag to install jupyterlab hub extensions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ conda_config:
   show_channel_urls: true
 
 install_nbextensions: yes
+install_labhubextensions: no
 
 base_lab_extensions: 
   - "@jupyterlab/hub-extension"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
 - name: Install Jupyter Lab extensions
   command: env -i PATH=$PATH bash -c '{{ conda_prefix }}/bin/jupyter labextension install {{ item }}'
   with_items: "{{ lab_extensions }}"
+  when: install_labhubextensions is defined and install_labhubextensions
 
 - include: install_r.yml
 


### PR DESCRIPTION
Adding a flag that defaults to False because hubextensions has a lot of problems that causes ci/cd pipeline to break. Very few users want it, and currently if I don't want to install it, I have to pass in an empty list as the lab_extensions field.